### PR TITLE
Fixed taskset of memtier to use the other 16 cores. currently both use the first 16.

### DIFF
--- a/bench-all.sh
+++ b/bench-all.sh
@@ -75,7 +75,7 @@ bench() {
     if [[ ! -f "$json" ]]; then
         ./bench $prog --threads=$threads --pipeline=$pipeline --perf=$perf \
             --ops=$nops --bthreads="$bthreads" --taskset="$ctaskset" \
-            --btaskset="$ctaskset" --sizerange="$sizerange" --conns="$conns"
+            --btaskset="$btaskset" --sizerange="$sizerange" --conns="$conns"
         chmod 666 bench.json
         mv bench.json $json
     fi


### PR DESCRIPTION
@tidwall thank you for these cool scripts. I've tried to replicate results on my end and noticed taskset is pinning both the servers and memtier to the same core range. Confirmed via 
<img width="1920" height="649" alt="image" src="https://github.com/user-attachments/assets/46b3af93-ed56-4935-84b4-ec22dfc6ad00" />

It's a simple typo. addressed in this PR. 
PS: now with cores properly split we can see results going up to 16 threads as expected :) 